### PR TITLE
SFR-653 Update Gutenberg EPUB filename extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import Parser from './src/epubParsers'
 import ResHandler from './src/responseHandlers'
 import logger from './src/helpers/logger'
 import LambdaError from './src/helpers/error'
+import { formatFileName } from './src/helpers/fileNameParser'
 
 const fileNameRegex = /[0-9]+[.]{1}epub[.]{1}(?:no|)images/
 
@@ -72,6 +73,7 @@ exports.parseRecord = (record) => {
 }
 
 exports.readFromKinesis = (record) => {
+  // eslint-disable-next-line new-cap
   const dataBlock = JSON.parse(new Buffer.from(record, 'base64').toString('ascii'))
   const payload = dataBlock.data
   const { url } = payload
@@ -83,7 +85,7 @@ exports.readFromKinesis = (record) => {
       code: 'regex-failure',
     })
   }
-  const fileName = fileNameMatch[0]
+  const fileName = formatFileName(fileNameMatch[0])
   const instanceID = payload.id
   const updated = new Date(payload.updated)
   const itemData = payload.data
@@ -96,7 +98,7 @@ exports.storeFromURL = (url, instanceID, updated, fileName, itemData) => {
     Parser.checkForExisting(fileName, updated).then(() => {
       axios({
         method: 'get',
-        url: url,
+        url,
         responseType: 'stream',
       })
         .then((response) => {

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ import logger from './src/helpers/logger'
 import LambdaError from './src/helpers/error'
 import { formatFileName } from './src/helpers/fileNameParser'
 
-const fileNameRegex = /[0-9]+[.]{1}epub[.]{1}(?:no|)images/
-
 exports.handler = async (event, context, callback) => {
   logger.debug('Handling input events from Kinesis stream')
   const records = event.Records;
@@ -77,15 +75,7 @@ exports.readFromKinesis = (record) => {
   const dataBlock = JSON.parse(new Buffer.from(record, 'base64').toString('ascii'))
   const payload = dataBlock.data
   const { url } = payload
-  const fileNameMatch = fileNameRegex.exec(url)
-  if (!fileNameMatch) {
-    logger.error('Provided URL failed to match regular expression')
-    throw new LambdaError(`Failed to extract file from url ${url}`, {
-      status: 500,
-      code: 'regex-failure',
-    })
-  }
-  const fileName = formatFileName(fileNameMatch[0])
+  const fileName = formatFileName(url)
   const instanceID = payload.id
   const updated = new Date(payload.updated)
   const itemData = payload.data

--- a/src/helpers/fileNameParser.js
+++ b/src/helpers/fileNameParser.js
@@ -1,6 +1,34 @@
-const fileNameRegex = /([0-9]+)\.epub\.((?:no)?images)$/
+import LambdaError from './error'
 
-const formatFileName = fileName => fileName.replace(fileNameRegex, '$1_$2.epub')
+/**
+ * Regex to validate ePub URLs. Must contain an .epub extension
+ * The first match group extracts the "filename", whatever follows the final slash in the URL path
+ * The second match group checks for an additional file extension, this is used by Project Gutenberg
+ */
+const fileNameRegex = /^.+\/(.+)\.epub\.?([a-zA-Z]*)$/
+
+/**
+ * This method validates an ePub URL and extracts the filename from the address.
+ * If the URL is found to contain an extra extension (such as Project Gutenberg's
+ * .no/images extensions) it extracts this and inserts it in the returned filename
+ *
+ * This process ensures that valid .epub filenames are returned for all input sources.
+ *
+ * @param {string} url The URL of a ePub file to be validated
+ *
+ * @returns {string} A .epub filename extracted from the provided URL
+ */
+const formatFileName = (url) => {
+  const urlMatch = fileNameRegex.exec(url)
+  if (!urlMatch) {
+    throw new LambdaError(`Failed to extract file from url ${url}`, {
+      status: 500,
+      code: 'regex-failure',
+    })
+  }
+  const extraFileExtension = urlMatch[2] ? `_${urlMatch[2]}` : ''
+  return `${urlMatch[1]}${extraFileExtension}.epub`
+}
 
 module.exports = {
   formatFileName,

--- a/src/helpers/fileNameParser.js
+++ b/src/helpers/fileNameParser.js
@@ -1,0 +1,7 @@
+const fileNameRegex = /([0-9]+)\.epub\.((?:no)?images)$/
+
+const formatFileName = fileName => fileName.replace(fileNameRegex, '$1_$2.epub')
+
+module.exports = {
+  formatFileName,
+}

--- a/test/fileNameParser.test.js
+++ b/test/fileNameParser.test.js
@@ -12,23 +12,23 @@ const { expect } = chai
 describe('helpers/fileNameParser', () => {
   describe('formatFileName(fileName)', () => {
     it('should return parsed Gutenberg EPUB filenames', (done) => {
-      const testFileName = '123456.epub.images'
+      const testFileName = 'http://gutenberg.org/hello/123456.epub.images'
       const parsedFileName = formatFileName(testFileName)
       expect(parsedFileName).to.equal('123456_images.epub')
       done()
     })
 
     it('should return parsed Gutenberg EPUB filenames with .noimages as well', (done) => {
-      const testFileName = '9876.epub.noimages'
+      const testFileName = 'http://gutenberg.org/hello/9876.epub.noimages'
       const parsedFileName = formatFileName(testFileName)
       expect(parsedFileName).to.equal('9876_noimages.epub')
       done()
     })
 
     it('should return non-standard filenames as-is', (done) => {
-      const testFileName = 'otherEpubFormat.epub'
+      const testFileName = 'http://gutenberg.org/hello/otherEpubFormat.epub'
       const parsedFileName = formatFileName(testFileName)
-      expect(parsedFileName).to.equal(testFileName)
+      expect(parsedFileName).to.equal('otherEpubFormat.epub')
       done()
     })
   })

--- a/test/fileNameParser.test.js
+++ b/test/fileNameParser.test.js
@@ -1,0 +1,35 @@
+/* eslint-disable semi, no-unused-expressions, no-undef */
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import sinonChai from 'sinon-chai'
+import { formatFileName } from '../src/helpers/fileNameParser'
+
+chai.should()
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+describe('helpers/fileNameParser', () => {
+  describe('formatFileName(fileName)', () => {
+    it('should return parsed Gutenberg EPUB filenames', (done) => {
+      const testFileName = '123456.epub.images'
+      const parsedFileName = formatFileName(testFileName)
+      expect(parsedFileName).to.equal('123456_images.epub')
+      done()
+    })
+
+    it('should return parsed Gutenberg EPUB filenames with .noimages as well', (done) => {
+      const testFileName = '9876.epub.noimages'
+      const parsedFileName = formatFileName(testFileName)
+      expect(parsedFileName).to.equal('9876_noimages.epub')
+      done()
+    })
+
+    it('should return non-standard filenames as-is', (done) => {
+      const testFileName = 'otherEpubFormat.epub'
+      const parsedFileName = formatFileName(testFileName)
+      expect(parsedFileName).to.equal(testFileName)
+      done()
+    })
+  })
+})

--- a/test/fileNameParser.test.js
+++ b/test/fileNameParser.test.js
@@ -31,5 +31,16 @@ describe('helpers/fileNameParser', () => {
       expect(parsedFileName).to.equal('otherEpubFormat.epub')
       done()
     })
+
+    it('should reject urls without .epub extension', (done) => {
+      const badFileName = 'http://gutenberg.org.ebook/actuallypdf123.pdf'
+      try {
+        formatFileName(badFileName)
+      } catch (err) {
+        expect(err.status).to.equal(500)
+        expect(err.code).to.equal('regex-failure')
+      }
+      done()
+    })
   })
 })

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -201,11 +201,10 @@ describe('Handlers [index.js]', () => {
 
     it('should throw LambdaError if regex match fails', () => {
       testData.data = {
-        url: 'http://www.gutenberg.org/ebooks/bad.epub.images',
-        id: 'bad',
+        url: 'http://www/gutenberg/org/notReal',
+        id: 'notreal',
         updated: moment().format(),
       }
-      testData.data.url = 'http://www/gutenberg/org/notReal'
       testRecord.kinesis.data = Buffer.from(JSON.stringify(testData)).toString('base64')
       try {
         results = Lambda.readFromKinesis(testRecord.kinesis.data)

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -182,7 +182,7 @@ describe('Handlers [index.js]', () => {
       expect(results[0]).to.equal('http://www.gutenberg.org/ebooks/10.epub.images')
       expect(results[1]).to.equal('10')
       expect(results[2]).to.deep.equal(new Date(testData.data.updated))
-      expect(results[3]).to.deep.equal('10_images.epub')
+      expect(results[3]).to.equal('10_images.epub')
     })
 
     it('should should transform 00000.epub.(no)images URLs', () => {
@@ -196,7 +196,7 @@ describe('Handlers [index.js]', () => {
       expect(results[0]).to.equal('http://www.gutenberg.org/ebooks/9999.epub.noimages')
       expect(results[1]).to.equal('9999')
       expect(results[2]).to.deep.equal(new Date(testData.data.updated))
-      expect(results[3]).to.deep.equal('9999_noimages.epub')
+      expect(results[3]).to.equal('9999_noimages.epub')
     })
 
     it('should throw LambdaError if regex match fails', () => {

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -162,11 +162,7 @@ describe('Handlers [index.js]', () => {
     let testData
     beforeEach(() => {
       testData = {
-        data: {
-          url: 'http://www.gutenberg.org/ebooks/10.epub.images',
-          id: '10',
-          updated: moment().format(),
-        },
+        data: null,
       }
       testRecord = {
         kinesis: {
@@ -176,14 +172,39 @@ describe('Handlers [index.js]', () => {
     })
 
     it('should return data fields', () => {
+      testData.data = {
+        url: 'http://www.gutenberg.org/ebooks/10.epub.images',
+        id: '10',
+        updated: moment().format(),
+      }
       testRecord.kinesis.data = Buffer.from(JSON.stringify(testData)).toString('base64')
       const results = Lambda.readFromKinesis(testRecord.kinesis.data)
       expect(results[0]).to.equal('http://www.gutenberg.org/ebooks/10.epub.images')
       expect(results[1]).to.equal('10')
       expect(results[2]).to.deep.equal(new Date(testData.data.updated))
+      expect(results[3]).to.deep.equal('10_images.epub')
+    })
+
+    it('should should transform 00000.epub.(no)images URLs', () => {
+      testData.data = {
+        url: 'http://www.gutenberg.org/ebooks/9999.epub.noimages',
+        id: '9999',
+        updated: moment().format(),
+      }
+      testRecord.kinesis.data = Buffer.from(JSON.stringify(testData)).toString('base64')
+      const results = Lambda.readFromKinesis(testRecord.kinesis.data)
+      expect(results[0]).to.equal('http://www.gutenberg.org/ebooks/9999.epub.noimages')
+      expect(results[1]).to.equal('9999')
+      expect(results[2]).to.deep.equal(new Date(testData.data.updated))
+      expect(results[3]).to.deep.equal('9999_noimages.epub')
     })
 
     it('should throw LambdaError if regex match fails', () => {
+      testData.data = {
+        url: 'http://www.gutenberg.org/ebooks/bad.epub.images',
+        id: 'bad',
+        updated: moment().format(),
+      }
       testData.data.url = 'http://www/gutenberg/org/notReal'
       testRecord.kinesis.data = Buffer.from(JSON.stringify(testData)).toString('base64')
       try {


### PR DESCRIPTION
Project Gutenberg stores its EPUB files with custom extensions `.images` and `.noimages` to distinguish between multiple copies of the same instance from their collection. While epub.js was able to read files in this format the webpub reader is not, nor is iBooks.

This transforms these filenames from the format `00000.epub.images` to `00000_images.epub` and does not transform and non-standard EPUB file names received from Gutenberg or other filenames received from other sources (as long as they end in .epub)