### PR TITLE
SFR-650 Add ereader flag to newly stored epub files

### DIFF
--- a/src/epubParsers.js
+++ b/src/epubParsers.js
@@ -98,6 +98,7 @@ exports.epubStore = (partName, instanceID, updated, type, response, itemData, fi
             url: data.Location,
             md5: data.ETag,
             flags: {
+              ereader: type === 'archive',
               local: true,
               download: epubDownload,
               images: epubImages,


### PR DESCRIPTION
The `ereader` flag is necessary for the webpub reader to recognize local .epub files as something that can be served to the reader. Currently this function does not append it to the correct files and this branch corrects that error.